### PR TITLE
add host and use normal bn

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,15 +9,14 @@ source:
   sha256: 1362acb01e468665dc38df84ff050cea222610981e196eeeb745c17de28d9bb1
 
 build:
-  number: 1000
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+  number: 1
   noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
 
 requirements:
-  build:
+  host:
     - python
     - pip
-
   run:
     - python
     - numpy


### PR DESCRIPTION
This is `noarch` and does not need the 1000 build number.